### PR TITLE
pin pydantic==1.10.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -27,7 +27,7 @@ requirements:
     - botorch >=0.8.2
     - gpytorch
     - pandas
-    - pydantic >=1.10.0
+    - pydantic ==1.10.9
     - orjson
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/ChristopherMayes/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 52b197fbf5f4fe49bce0fb5a1408bcaab506b7f491bdc91125cb6fa904071502
+  sha256: bbc922224f0fc09212d3dfd2c328151198ea38bdd1dd64b9a824f9d1dbb6127f
 
 build:
   noarch: python


### PR DESCRIPTION
Pedantic is now at v2, but Xopt is not yet compatible. This pins pydantic to the last v1. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
